### PR TITLE
Update Github Action for Publishing to Comfy Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
   publish-node:
     name: Publish Custom Node to registry
     needs: check-version
-    if: ${{ needs.check-version.outputs.should_publish == 'true' }}
+    if: ${{ needs.check-version.outputs.should_publish == 'true' && github.repository_owner == 'Kidev' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. This PR updates the Github Action `publish.yml` to ensure latest ComfyUI Community Standard.

## Updates:

2. **Conditional Execution**: Only runs the publish job in author’s repo, defaults to repo owner, reference issue here: - [Forks problem: add an organisation or owner check to run the action · Issue #2 · Comfy-Org/publish-node-action](https://github.com/Comfy-Org/publish-node-action/issues/2)

```diff
-     if: ${{ needs.check-version.outputs.should_publish == 'true' }}
+     if: ${{ needs.check-version.outputs.should_publish == 'true' && github.repository_owner == 'Kidev' }}
```

## Learn More

Please message me on Discord at robin or join our [server](https://discord.com/invite/comfyorg) server if you have any questions! For more information, visit the official Comfy-Org blog: [ComfyUI Blog](https://blog.comfy.org/).